### PR TITLE
fixing missing info in profession window

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -44,6 +44,23 @@ end
 
 function BagBrother:ParseItem(link, count)
 	if link then
+	-- begin hotfix profession window
+	local itemId = tonumber(string.match(link, "item:(%d+):"))	-- get itemID // itemID seems to be "0" for every reagent in profession window?!
+		if (itemId == 0 and TradeSkillFrame ~= nil and TradeSkillFrame:IsVisible()) then -- some other frames show ID = 0 aswell, so limit this workaround to the profession window || IMPORTANT: TradeSkillFrame ~= nil has to be checked BEFORE TradeSkillFrame:IsVisible()
+			local newItemId
+			if ((GetMouseFocus():GetName()) == "TradeSkillSkillIcon") then 			--replace TradeSkill
+				newItemId = tonumber(GetTradeSkillItemLink(TradeSkillFrame.selectedSkill):match("item:(%d+):"))
+			else 		-- could check if a reagent is under mouse, but since we have to check it 3 lines later again...
+				for i = 1, 12 do 													-- how many reagents can a reciepe have? lets assume not more than 12
+					if ((GetMouseFocus():GetName()) == "TradeSkillReagent"..i) then 	--replace TradeSkillReagents
+						newItemId = tonumber(GetTradeSkillReagentItemLink(TradeSkillFrame.selectedSkill, i):match("item:(%d+):"))
+						break 			--end loop if correct one already found
+					end
+				end
+			end
+			_, link = GetItemInfo(newItemId) -- replace original link with our found link
+		end
+		-- end hotfix profession window
 		if link:find('0:0:0:0:0:%d+:%d+:%d+:0:0') then
 			link = link:match('|H%l+:(%d+)')
 		else


### PR DESCRIPTION
There is a know bug with one of Blizzards get-functions, that results in missing information in the profession window (and various other windows). This is a workaround for the profession window.