### PR TITLE
Cache item count

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -38,12 +38,16 @@ function BagBrother:SaveBag(bag, onlyItems)
 end
 
 function BagBrother:SaveEquip(i, count)
+	local oldLink = self.Player.equip[i]
 	local link = GetInventoryItemLink('player', i)
 
 	count = count or GetInventoryItemCount('player', i)
+	link = self:ParseItem(link, count)
 
-	self.Player.equip[i] = self:ParseItem(link, count)
-	addon:UnCachePlayerBag('equip')
+	if (link ~= oldLink) then
+		self.Player.equip[i] = link
+		addon:UnCachePlayerBag('equip')
+	end
 end
 
 function BagBrother:ParseItem(link, count)

--- a/API.lua
+++ b/API.lua
@@ -28,7 +28,7 @@ function BagBrother:SaveBag(bag, onlyItems, saveSize)
 		end
 
 		if not onlyItems then
-			self:SaveEquip(ContainerIDToInventoryID(bag), size)
+			self:SaveEquip(ContainerIDToInventoryID(bag), 1)
 		elseif saveSize then
 			items.size = size
 		end
@@ -41,7 +41,8 @@ end
 
 function BagBrother:SaveEquip(i, count)
 	local link = GetInventoryItemLink('player', i)
-	local count = count or GetInventoryItemCount('player', i)
+
+	count = count or GetInventoryItemCount('player', i)
 
 	self.Player.equip[i] = self:ParseItem(link, count)
 end

--- a/API.lua
+++ b/API.lua
@@ -20,23 +20,20 @@ local BagBrother = addon.BagBrother
 
 function BagBrother:SaveBag(bag, onlyItems)
 	local size = GetContainerNumSlots(bag)
-	if size > 0 then
-		local items = {}
 
-		for slot = 1, size do
-			local _, count, _,_,_,_, link = GetContainerItemInfo(bag, slot)
-			items[slot] = self:ParseItem(link, count)
-		end
+	local items = {}
 
-		if not onlyItems then
-			self:SaveEquip(ContainerIDToInventoryID(bag), 1)
-		end
-
-		items.size = size
-		self.Player[bag] = items
-	else
-		self.Player[bag] = nil
+	for slot = 1, size do
+		local _, count, _,_,_,_, link = GetContainerItemInfo(bag, slot)
+		items[slot] = self:ParseItem(link, count)
 	end
+
+	if not onlyItems then
+		self:SaveEquip(ContainerIDToInventoryID(bag), 1)
+	end
+
+	items.size = size
+	self.Player[bag] = items
 end
 
 function BagBrother:SaveEquip(i, count)

--- a/API.lua
+++ b/API.lua
@@ -34,7 +34,7 @@ function BagBrother:SaveBag(bag, onlyItems)
 
 	items.size = size
 	self.Player[bag] = items
-	addon:UnCachePlayerBag('bags')
+	addon:UnCachePlayerBag(bag)
 end
 
 function BagBrother:SaveEquip(i, count)

--- a/API.lua
+++ b/API.lua
@@ -15,6 +15,8 @@ along with the addon. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 This file is part of BagBrother.
 --]]
 
+local _, addon = ...
+local BagBrother = addon.BagBrother
 
 function BagBrother:SaveBag(bag, onlyItems, saveSize)
 	local size = GetContainerNumSlots(bag)

--- a/API.lua
+++ b/API.lua
@@ -18,10 +18,11 @@ This file is part of BagBrother.
 local _, addon = ...
 local BagBrother = addon.BagBrother
 
-function BagBrother:SaveBag(bag, onlyItems, saveSize)
+function BagBrother:SaveBag(bag, onlyItems)
 	local size = GetContainerNumSlots(bag)
 	if size > 0 then
 		local items = {}
+
 		for slot = 1, size do
 			local _, count, _,_,_,_, link = GetContainerItemInfo(bag, slot)
 			items[slot] = self:ParseItem(link, count)
@@ -29,10 +30,9 @@ function BagBrother:SaveBag(bag, onlyItems, saveSize)
 
 		if not onlyItems then
 			self:SaveEquip(ContainerIDToInventoryID(bag), 1)
-		elseif saveSize then
-			items.size = size
 		end
 
+		items.size = size
 		self.Player[bag] = items
 	else
 		self.Player[bag] = nil

--- a/API.lua
+++ b/API.lua
@@ -34,6 +34,7 @@ function BagBrother:SaveBag(bag, onlyItems)
 
 	items.size = size
 	self.Player[bag] = items
+	addon:UnCachePlayerBag('bags')
 end
 
 function BagBrother:SaveEquip(i, count)
@@ -42,6 +43,7 @@ function BagBrother:SaveEquip(i, count)
 	count = count or GetInventoryItemCount('player', i)
 
 	self.Player.equip[i] = self:ParseItem(link, count)
+	addon:UnCachePlayerBag('equip')
 end
 
 function BagBrother:ParseItem(link, count)

--- a/BagBrother.toc
+++ b/BagBrother.toc
@@ -6,6 +6,7 @@
 ## OptionalDeps: LibStub, WoWUnit
 
 LibStub.lua
+ItemCount.lua
 Startup.lua
 Events.lua
 API.lua

--- a/Events.lua
+++ b/Events.lua
@@ -45,6 +45,10 @@ function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)
 	self:SaveEquip(slot)
 end
 
+function BagBrother:BAG_CLOSED(slot)
+	self:SaveEquip(ContainerIDToInventoryID(slot))
+end
+
 function BagBrother:PLAYER_MONEY()
 	self.Player.money = GetMoney()
 end

--- a/Events.lua
+++ b/Events.lua
@@ -45,8 +45,8 @@ function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)
 	self:SaveEquip(slot)
 end
 
-function BagBrother:BAG_CLOSED(slot)
-	self:SaveEquip(ContainerIDToInventoryID(slot))
+function BagBrother:BAG_CLOSED(bag)
+	self:SaveBag(bag)
 end
 
 function BagBrother:PLAYER_MONEY()

--- a/Events.lua
+++ b/Events.lua
@@ -22,10 +22,20 @@ local LAST_BANK_SLOT = NUM_BANKBAGSLOTS + NUM_BAG_SLOTS
 
 --[[ Continuous Events ]]--
 
+BagBrother.flaggedBags = {}
+
 function BagBrother:BAG_UPDATE(bag)
-	if bag <= NUM_BAG_SLOTS then
-  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
+	self.flaggedBags[bag] = true
+end
+
+function BagBrother:BAG_UPDATE_DELAYED()
+	for bag in pairs(self.flaggedBags) do
+		if bag <= NUM_BAG_SLOTS then
+	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
+		end
 	end
+
+	self.flaggedBags = {}
 end
 
 function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)

--- a/Events.lua
+++ b/Events.lua
@@ -28,111 +28,116 @@ local LAST_BANK_SLOT = NUM_BANKBAGSLOTS + NUM_BAG_SLOTS
 BagBrother.flaggedBags = {}
 
 function BagBrother:BAG_UPDATE(bag)
-	self.flaggedBags[bag] = true
+  self.flaggedBags[bag] = true
 end
 
 function BagBrother:BAG_UPDATE_DELAYED()
-	for bag in pairs(self.flaggedBags) do
-		if bag <= NUM_BAG_SLOTS then
-	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER)
-		end
-	end
+  for bag in pairs(self.flaggedBags) do
+    if bag <= NUM_BAG_SLOTS then
+      self:SaveBag(bag, bag <= BACKPACK_CONTAINER)
+    end
+  end
 
-	self.flaggedBags = {}
+  self.flaggedBags = {}
 end
 
 function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)
-	self:SaveEquip(slot)
+  self:SaveEquip(slot)
 end
 
 function BagBrother:BAG_CLOSED(bag)
-	self:SaveBag(bag)
+  self:SaveBag(bag)
 end
 
 function BagBrother:PLAYER_MONEY()
-	self.Player.money = GetMoney()
+  self.Player.money = GetMoney()
 end
 
 
 --[[ Bank Events ]]--
 
 function BagBrother:BANKFRAME_OPENED()
-	self.atBank = true
+  self.atBank = true
 end
 
 function BagBrother:BANKFRAME_CLOSED()
-	if self.atBank then
-		for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
-			self:SaveBag(i)
-		end
+  if self.atBank then
+    for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
+      self:SaveBag(i)
+    end
 
-		if REAGENTBANK_CONTAINER and IsReagentBankUnlocked() then
-			self:SaveBag(REAGENTBANK_CONTAINER, true)
-		end
+    if REAGENTBANK_CONTAINER and IsReagentBankUnlocked() then
+      self:SaveBag(REAGENTBANK_CONTAINER, true)
+    end
 
-		self:SaveBag(BANK_CONTAINER, true)
-		self.atBank = nil
-	end
+    self:SaveBag(BANK_CONTAINER, true)
+    self.atBank = nil
+  end
 end
 
 
 --[[ Void Storage Events ]]--
 
 function BagBrother:VOID_STORAGE_OPEN()
-	self.atVault = true
+  self.atVault = true
 end
 
 function BagBrother:VOID_STORAGE_CLOSE()
-	if self.atVault then
-		self.Player.vault = {}
-		self.atVault = nil
+  if self.atVault then
+    self.Player.vault = {}
+    self.atVault = nil
 
-		for i = 1, NUM_VAULT_SLOTS do
-			local id = GetVoidItemInfo(1, i)
-    		self.Player.vault[i] = id and tostring(id) or nil
-  		end
-  	end
+    for i = 1, NUM_VAULT_SLOTS do
+      local id = GetVoidItemInfo(1, i)
+
+      self.Player.vault[i] = id and tostring(id) or nil
+    end
+
+    addon:UnCachePlayerBag('vault')
+  end
 end
 
 
 --[[ Guild Events ]]--
 
 function BagBrother:GUILDBANKFRAME_OPENED()
-	self.atGuild = true
+  self.atGuild = true
 end
 
 function BagBrother:GUILDBANKFRAME_CLOSED()
-	self.atGuild = nil
+  self.atGuild = nil
 end
 
 function BagBrother:GUILD_ROSTER_UPDATE()
-	self.Player.guild = GetGuildInfo('player')
+  self.Player.guild = GetGuildInfo('player')
 end
 
 function BagBrother:GUILDBANKBAGSLOTS_CHANGED()
-	if self.atGuild then
-		local id = GetGuildInfo('player') .. '*'
-		local guild = self.Realm[id] or {}
-		guild.faction = UnitFactionGroup('player') == 'Alliance'
+  if self.atGuild then
+    local id = GetGuildInfo('player') .. '*'
+    local guild = self.Realm[id] or {}
+    guild.faction = UnitFactionGroup('player') == 'Alliance'
 
-		for i = 1, GetNumGuildBankTabs() do
-			guild[i] = guild[i] or {}
-			guild[i].name, guild[i].icon, guild[i].view = GetGuildBankTabInfo(i)
-		end
+    for i = 1, GetNumGuildBankTabs() do
+      guild[i] = guild[i] or {}
+      guild[i].name, guild[i].icon, guild[i].view = GetGuildBankTabInfo(i)
+    end
 
-		local tab = GetCurrentGuildBankTab()
-		local items = guild[tab]
-		if items then
-			items.deposit, items.withdraw, items.remaining = select(4, GetGuildBankTabInfo(tab))
+    local tab = GetCurrentGuildBankTab()
+    local items = guild[tab]
+    if items then
+      items.deposit, items.withdraw, items.remaining = select(4, GetGuildBankTabInfo(tab))
 
-			for i = 1, 98 do
-				local link = GetGuildBankItemLink(tab, i)
-				local _, count = GetGuildBankItemInfo(tab, i)
+      for i = 1, 98 do
+        local link = GetGuildBankItemLink(tab, i)
+        local _, count = GetGuildBankItemInfo(tab, i)
 
-				items[i] = self:ParseItem(link, count)
-			end
-		end
+        items[i] = self:ParseItem(link, count)
+      end
+    end
 
-		self.Realm[id] = guild
-	end
+    self.Realm[id] = guild
+
+    addon:UnCacheRealmOwner(id)
+  end
 end

--- a/Events.lua
+++ b/Events.lua
@@ -34,7 +34,7 @@ end
 function BagBrother:BAG_UPDATE_DELAYED()
 	for bag in pairs(self.flaggedBags) do
 		if bag <= NUM_BAG_SLOTS then
-	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
+	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER)
 		end
 	end
 

--- a/Events.lua
+++ b/Events.lua
@@ -15,6 +15,9 @@ along with the addon. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 This file is part of BagBrother.
 --]]
 
+local _, addon = ...
+local BagBrother = addon.BagBrother
+
 local NUM_VAULT_SLOTS = 80 * 2
 local FIRST_BANK_SLOT = 1 + NUM_BAG_SLOTS
 local LAST_BANK_SLOT = NUM_BANKBAGSLOTS + NUM_BAG_SLOTS

--- a/Interface.lua
+++ b/Interface.lua
@@ -88,20 +88,27 @@ end
 --[[ Bags ]]--
 
 function Interface:GetBag(realm, player, bag)
-  if tonumber(bag) then
-    local slot = bag > 0 and ContainerIDToInventoryID(bag)
-    if slot then
-      return Interface:GetItem(realm, player, 'equip', slot)
-    else
-      realm = BrotherBags[realm]
-      player = realm and realm[player]
-      bag = player and player[bag]
+  bag = tonumber(bag)
 
-      return bag and {
-        owned = true,
-        count = bag.size }
-    end
+  if not bag then return end
+
+  local item
+
+  if (bag > 0) then
+    item = Interface:GetItem(realm, player, 'equip', ContainerIDToInventoryID(bag))
+  else
+    item = {}
   end
+
+  realm = BrotherBags[realm]
+  player = realm and realm[player]
+  bag = player and player[bag]
+
+  return bag and item and {
+    owned = true,
+    count = bag.size,
+    link = item.link,
+  }
 end
 
 function Interface:GetGuildTab(realm, guild, tab)

--- a/Interface.lua
+++ b/Interface.lua
@@ -15,6 +15,8 @@ along with the addon. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 This file is part of BagBrother.
 --]]
 
+local addonName, addon = ...
+
 local Interface = LibStub:NewLibrary('BagBrotherInterface', 1)
 Interface.IsItemCache = true
 
@@ -131,6 +133,14 @@ function Interface:GetItem(realm, owner, bag, slot)
   end
 end
 
+function Interface:GetItemCount(realm, owner, bag, itemId)
+  return addon:GetItemCount(realm, owner, bag, itemId)
+end
+
 function Interface:GetGuildItem(realm, name, tab, slot)
   return Interface:GetItem(realm, name .. '*', tab, slot)
+end
+
+function Interface:GetGuildItemCount(realm, owner, bag, itemId)
+  return addon:GetItemCount(realm, owner .. '*', bag, itemId)
 end

--- a/ItemCount.lua
+++ b/ItemCount.lua
@@ -57,12 +57,7 @@ end
 local function initItemCountCache(realm, owner)
   local BrotherBags = _G.BrotherBags or {}
   local realmData = BrotherBags[realm]
-
-  if (realmData == nil) then
-    return false
-  end
-
-  local ownerData = realmData[owner]
+  local ownerData = realmData and realmData[owner]
 
   if (ownerData == nil) then
     return false
@@ -106,16 +101,11 @@ function addon:GetItemCount (realm, owner, bag, itemId)
 
   bag = getBagType(bag)
 
-  if ((data == nil or data[owner] == nil) and
-      not initItemCountCache(realm, owner)) then
+  if (not (data and data[owner]) and not initItemCountCache(realm, owner)) then
     return 0
   end
 
   data = itemCountCache[realm][owner][bag]
 
-  if (data == nil) then
-    return 0
-  end
-
-  return data[itemId] or 0
+  return (data and data[itemId]) or 0
 end

--- a/ItemCount.lua
+++ b/ItemCount.lua
@@ -92,11 +92,7 @@ local function initItemCountCache(realm, owner)
           count = count or 1
           count = tonumber(count)
 
-          if (bagCounts[id] == nil) then
-            bagCounts[id] = count
-          else
-            bagCounts[id] = bagCounts[id] + count
-          end
+          bagCounts[id] = (bagCounts[id] or 0) + count
         end
       end
     end
@@ -115,6 +111,7 @@ function addon:GetItemCount (realm, owner, bag, itemId)
     return 0
   end
 
+  bag = getBagType(bag)
   data = itemCountCache[realm][owner][bag]
 
   if (data == nil) then

--- a/ItemCount.lua
+++ b/ItemCount.lua
@@ -1,0 +1,125 @@
+--[[
+Copyright 2011-2020 João Cardoso
+BagBrother is distributed under the terms of the GNU General Public License (Version 3).
+As a special exception, the copyright holders of this addon do not give permission to
+redistribute and/or modify it.
+
+This addon is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the addon. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
+
+This file is part of BagBrother.
+--]]
+
+local _, addon = ...
+local BagBrother = addon.BagBrother
+
+local FIRST_BAG_SLOT = BACKPACK_CONTAINER
+local LAST_BAG_SLOT = FIRST_BAG_SLOT + NUM_BAG_SLOTS
+local LAST_BANK_SLOT = NUM_BAG_SLOTS + NUM_BANKBAGSLOTS
+local FIRST_BANK_SLOT = NUM_BAG_SLOTS + 1
+local BAG_TYPE_BANK = 'bank'
+local BAG_TYPE_BAG = 'bags'
+
+local itemCountCache = {}
+
+local function getBagType (bag)
+  if (type(bag) ~= 'number') then
+    return bag
+  end
+
+  if (bag >= FIRST_BAG_SLOT and bag <= LAST_BAG_SLOT) then
+    return BAG_TYPE_BAG
+  end
+
+  if (bag == BANK_CONTAINER) then
+    return BAG_TYPE_BANK
+  end
+
+  if (bag >= FIRST_BANK_SLOT and bag <= LAST_BANK_SLOT) then
+    return BAG_TYPE_BANK
+  end
+
+  if (REAGENTBANK_CONTAINER ~= nil and bag == REAGENTBANK_CONTAINER) then
+    return BAG_TYPE_BANK
+  end
+
+  -- this part should never be reached
+  return BAG_TYPE_BAG
+end
+
+local function initItemCountCache(realm, owner)
+  local BrotherBags = _G.BrotherBags or {}
+  local realmCache = itemCountCache[realm] or {}
+  local realmData = BrotherBags[realm]
+
+  if (realmData == nil) then
+    itemCountCache[realm] = false
+    return false
+  end
+
+  local ownerData = realmData[owner]
+
+  itemCountCache[realm] = realmCache
+
+  if (ownerData == nil) then
+    realmCache[owner] = false
+    return false
+  end
+
+  local ownerCache = {}
+
+  realmCache[owner] = ownerCache;
+
+  for bag, bagData in pairs (ownerData) do
+    if (type(bagData) == 'table') then
+      local bagCounts
+
+      bag = getBagType(bag)
+      ownerCache[bag] = ownerCache[bag] or {}
+      bagCounts = ownerCache[bag]
+
+      for slot, item in pairs(bagData) do
+        if (type(slot) == 'number' and type(item) == 'string') then
+          local link, count = strsplit(';', item)
+          local id = strsplit(':', link)
+
+          id = tonumber(id)
+          count = count or 1
+          count = tonumber(count)
+
+          if (bagCounts[id] == nil) then
+            bagCounts[id] = count
+          else
+            bagCounts[id] = bagCounts[id] + count
+          end
+        end
+      end
+    end
+  end
+end
+
+function addon:GetItemCount (realm, owner, bag, itemId)
+  local data = itemCountCache[realm]
+
+  if (data == false) then
+    return 0
+  end
+
+  if ((data == nil or data[owner] == nil) and not
+      initItemCountCache(realm, owner)) then
+    return 0
+  end
+
+  data = itemCountCache[realm][owner][bag]
+
+  if (data == nil) then
+    return 0
+  end
+
+  return data[itemId] or 0
+end

--- a/ItemCount.lua
+++ b/ItemCount.lua
@@ -22,7 +22,6 @@ local FIRST_BAG_SLOT = BACKPACK_CONTAINER
 local LAST_BAG_SLOT = FIRST_BAG_SLOT + NUM_BAG_SLOTS
 local LAST_BANK_SLOT = NUM_BAG_SLOTS + NUM_BANKBAGSLOTS
 local FIRST_BANK_SLOT = NUM_BAG_SLOTS + 1
-local LAST_INVENTORY_SLOT = ContainerIDToInventoryID(NUM_BAG_SLOTS);
 local BAG_TYPE_BANK = 'bank'
 local BAG_TYPE_BAG = 'bags'
 local BAG_TYPE_EQUIP = 'equip'
@@ -74,8 +73,7 @@ local function initItemCountCache(realm, owner)
       bagCounts = ownerCache[bag] or {}
 
       for slot, item in pairs(bagData) do
-        if (type(slot) == 'number' and type(item) == 'string' and
-            (bag ~= BAG_TYPE_EQUIP or slot <= LAST_INVENTORY_SLOT)) then
+        if (type(slot) == 'number' and type(item) == 'string') then
           local link, count = strsplit(';', item)
           local id = strsplit(':', link)
 

--- a/Startup.lua
+++ b/Startup.lua
@@ -15,11 +15,13 @@ along with the addon. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 This file is part of BagBrother.
 --]]
 
+local _, addon = ...
 
 local Brother = CreateFrame('Frame', 'BagBrother')
 Brother:SetScript('OnEvent', function(self, event, ...) self[event](self, ...) end)
 Brother:RegisterEvent('PLAYER_LOGIN')
 
+addon.BagBrother = Brother
 
 --[[ Server Ready ]]--
 

--- a/Startup.lua
+++ b/Startup.lua
@@ -48,6 +48,7 @@ end
 
 function Brother:SetupEvents()
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_UPDATE_DELAYED')
 	self:RegisterEvent('PLAYER_MONEY')
 	self:RegisterEvent('GUILD_ROSTER_UPDATE')
 	self:RegisterEvent('PLAYER_EQUIPMENT_CHANGED')
@@ -70,6 +71,8 @@ function Brother:UpdateData()
 	for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
 		self:BAG_UPDATE(i)
 	end
+
+	self:BAG_UPDATE_DELAYED()
 
 	for i = 1, INVSLOT_LAST_EQUIPPED do
 		self:PLAYER_EQUIPMENT_CHANGED(i)

--- a/Startup.lua
+++ b/Startup.lua
@@ -51,6 +51,7 @@ end
 function Brother:SetupEvents()
 	self:RegisterEvent('BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE_DELAYED')
+	self:RegisterEvent('BAG_CLOSED')
 	self:RegisterEvent('PLAYER_MONEY')
 	self:RegisterEvent('GUILD_ROSTER_UPDATE')
 	self:RegisterEvent('PLAYER_EQUIPMENT_CHANGED')


### PR DESCRIPTION
With this change, BagBrother will have an Interface for getting the count of an item for a specific owner and bag type. BagBrother will cache the count, so repeated calls will have a minimum impact.
When using this API, lag spikes caused by mousing over items in Bagnon are minimized, as these counts are not recalculated every time and on every tooltip update.
In my tests, the memory consumption of BagBrother went from about 1MB to 1.2MB on a server with 12 cached characters, which is a great tradeoff for the big performance increase.