### PR TITLE
Collect BAG_UPDATE events to improve performance

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -22,20 +22,20 @@ local LAST_BANK_SLOT = NUM_BANKBAGSLOTS + NUM_BAG_SLOTS
 
 --[[ Continuous Events ]]--
 
-BagBrother.flaggedBags = {}
+BagBrother.queue = {}
 
 function BagBrother:BAG_UPDATE(bag)
-	self.flaggedBags[bag] = true
+	self.queue[bag] = true
 end
 
 function BagBrother:BAG_UPDATE_DELAYED()
-	for bag in pairs(self.flaggedBags) do
+	for bag in pairs(self.queue) do
 		if bag <= NUM_BAG_SLOTS then
 	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
 		end
 	end
 
-	self.flaggedBags = {}
+	self.queue = {}
 end
 
 function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)

--- a/Events.lua
+++ b/Events.lua
@@ -22,10 +22,20 @@ local LAST_BANK_SLOT = NUM_BANKBAGSLOTS + NUM_BAG_SLOTS
 
 --[[ Continuous Events ]]--
 
+BagBrother.flaggedBags = {}
+
 function BagBrother:BAG_UPDATE(bag)
-	if bag <= NUM_BAG_SLOTS then
-  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
+	self.flaggedBags[bag] = true
+end
+
+function BagBrother:BAG_UPDATE_DELAYED()
+	for bag in pairs(self.flaggedBags) do
+		if bag <= NUM_BAG_SLOTS then
+	  	self:SaveBag(bag, bag <= BACKPACK_CONTAINER, bag == KEYRING_CONTAINER and HasKey and HasKey())
+		end
 	end
+
+	self.flaggedBags = {}
 end
 
 function BagBrother:PLAYER_EQUIPMENT_CHANGED(slot)

--- a/Startup.lua
+++ b/Startup.lua
@@ -48,6 +48,7 @@ end
 
 function Brother:SetupEvents()
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_UPDATE_DELAYED')
 	self:RegisterEvent('PLAYER_MONEY')
 	self:RegisterEvent('GUILD_ROSTER_UPDATE')
 	self:RegisterEvent('PLAYER_EQUIPMENT_CHANGED')
@@ -70,6 +71,8 @@ function Brother:UpdateData()
 	for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
 		self:BAG_UPDATE(i)
 	end
+
+	self:BAG_UPDATE_DELAYED()
 
 	for i = 1, INVSLOT_LAST_EQUIPPED do
 		self:PLAYER_EQUIPMENT_CHANGED(i)


### PR DESCRIPTION
When moving items inside a bag, the BAG_UPDATE event fires at least 2 times for that bag.
By collecting these events and only updating once, bags don't get updated multiple times needlessly.