### PR TITLE
Update French translations

### DIFF
--- a/config/localization/fr.lua
+++ b/config/localization/fr.lua
@@ -6,24 +6,23 @@ local CONFIG = ...
 local L = LibStub('AceLocale-3.0'):NewLocale(CONFIG, 'frFR')
 if not L then return end
 
--- global
-L.ConfirmGlobals = 'Êtes-vous sûr de vouloir désactiver les paramètres spécifiques à ce personnage ? Tous les paramètres spécifiques seront perdus.'
-
 -- general
 L.GeneralOptionsDesc = 'Configuration des options générales de %s'
 L.Locked = 'Bloquer la position des fenêtres'
 L.TipCount = 'Activer l\'info-bulle du compteur d\'objets'
 L.CountGuild = 'Inclure les banques de guilde'
 L.FlashFind = 'Activer résultat éclair'
-L.EmptySlots = 'Afficher un fond sur les emplacements vides'
 L.DisplayBlizzard = 'Afficher les cadres de Blizzard pour les sacs désactivés'
+L.DisplayBlizzardTip = 'Si activé, le panneau Blizzard par défaut sera affiché pour les sacs et containers de banque cachés.\n\n|cffff1919Nécessite de recharger l\'UI.|r'
+L.ConfirmGlobals = 'Êtes-vous sûr de vouloir désactiver les paramètres spécifiques à ce personnage ? Tous les paramètres spécifiques seront perdus.'
+L.CharacterSpecific = 'Paramètres spécifiques au personnage'
 
 -- frame
 L.FrameOptions = 'Options des fenêtres'
 L.FrameOptionsDesc = 'Configuration des options spécifiques à une fenêtre de %s'
 L.Frame = 'Fenêtre'
 L.Enabled = 'Activer'
-L.CharacterSpecific = 'Paramètres spécifiques au personnage'
+L.EnabledTip = 'Si désactivé, l\'UI Blizzard par defaut ne sera pas affichée pour cette fenêtre.\n\n|cffff1919Nécessite de recharger l\'UI.|r'
 L.ActPanel = 'Se comporter comme un panneau standard'
 L.ActPanelTip = [[
 Si activé, ce panneau se positionnera
@@ -32,12 +31,19 @@ le font, tels que le |cffffffffGrimoire|r ou la |cffffffffRecherche de groupe|r,
 et ne pourra pas être déplacé.]]
 
 L.BagToggle = 'Fenêtre du sac'
-L.Money = 'Affichage des revenus'
 L.Broker = 'Activer le DataBroker'
+L.Currency = 'Monnaies'
+L.ExclusiveReagent = 'Séparer la banque des composants'
+L.Money = 'Affichage des revenus'
 L.Sort = 'Bouton de tri'
 L.Search = 'Champ de recherche'
 L.Options = 'Affichage des options'
-L.ExclusiveReagent = 'Séparer la banque des composants'
+--[[
+L.LeftTabs = 'Rulesets on Left'
+L.LeftTabsTip = [[
+If enabled, the side tabs will be
+displayed on the left side of the panel.]]
+-- ]]
 
 L.Appearance = 'Apparence'
 L.Layer = 'Couche'
@@ -61,31 +67,41 @@ L.DisplayOptionsDesc = 'Options de l\'affichage automatique'
 L.DisplayInventory = 'Afficher votre inventaire'
 L.CloseInventory = 'Fermer votre inventaire'
 
-L.Banker = 'quand vous visitez la banque'
 L.Auctioneer = 'quand vous visitez l\'hôtel des ventes'
-L.TradePartner = 'quand vous parlez à un commerçant'
-L.Crafting = 'quand vous craftez'
-L.MailInfo = 'quand vous relevez votre courrier'
-L.GuildBanker = 'quand vous visitez votre banque de guilde'
-L.PlayerFrame = 'quand vous ouvrez la fenêtre de votre personnage'
-L.Socketing = 'quand vous sertissez vos objets'
-L.Merchant = 'quand vous quittez un marchand'
-
+L.Banker = 'quand vous visitez la banque'
 L.Combat = 'quand vous entrez en combat'
-L.Vehicle = 'quand vous montez dans un véhicule'
+L.Crafting = 'quand vous craftez'
+L.GuildBanker = 'quand vous visitez votre banque de guilde'
+L.VoidStorageBanker = 'quand vous visitez la chambre du vide'
+L.MailInfo = 'quand vous relevez votre courrier'
 L.MapFrame = 'quand vous ouvrez la carte du monde'
+L.Merchant = 'quand vous quittez un marchand'
+L.PlayerFrame = 'quand vous ouvrez la fenêtre de votre personnage'
+L.ScrappingMachine = 'quand vous visitez le ferailleur'
+L.Socketing = 'quand vous sertissez vos objets'
+L.TradePartner = 'quand vous parlez à un commerçant'
+L.Vehicle = 'quand vous montez dans un véhicule'
 
 -- colors
 L.ColorOptions = 'Options de couleur'
 L.ColorOptionsDesc = 'Options de colorisation des emplacements'
+
 L.GlowQuality = 'Surligner les objets par qualité'
-L.GlowNew = 'Surligner les nouveaux objets'
 L.GlowQuest = 'Surligner les objets de quête'
 L.GlowUnusable = 'Surligner les objets inutiles'
 L.GlowSets = 'Surligner les objets d\'ensemble'
-L.ColorSlots = 'Colorier les emplacements vides par type de sac'
+L.GlowNew = 'Surligner les nouveaux objets'
+L.GlowPoor = 'Surligner les objets de faible qualité'
+L.GlowAlpha = 'Contour lumineux des objets'
 
+L.EmptySlots = 'Afficher un fond sur les emplacements vides'
+L.SlotBackground = 'Artwork'
+L.ColorSlots = 'Colorier les emplacements vides par type de sac'
 L.NormalColor = 'Normaux'
+L.KeyColor = 'Clés'
+L.QuiverColor = 'Carquois'
+L.SoulColor = 'Sac d\'âmes
+L.ReagentColor = 'Banque des composants'
 L.LeatherColor = 'Sac Travail du cuir'
 L.InscribeColor = 'Sac Calligraphie'
 L.HerbColor = 'Sac Herboristerie'
@@ -94,9 +110,7 @@ L.EngineerColor = 'Sac Ingénierie'
 L.GemColor = 'Sac de Gemmes'
 L.MineColor = 'Sac de Minage'
 L.TackleColor = 'Sac de Pêche'
-L.RefrigeColor = 'Sac de Cuisine '
-L.ReagentColor = 'Banque des composants'
-L.GlowAlpha = 'Contour lumineux des objets'
+L.FridgeColor = 'Sac de Cuisine'
 
 -- rulesets
 L.RuleOptions = 'Item Rulesets'

--- a/core/localization/fr.lua
+++ b/core/localization/fr.lua
@@ -13,7 +13,7 @@ L.ToggleGuild = 'Afficher votre banque de guilde'
 L.ToggleVault = 'Afficher votre chambre du Vide'
 
 --terminal
-L.Commands = 'Liste des commandes :'
+L.Commands = 'Liste des commandes :'
 L.CmdShowInventory = 'Affiche ou cache votre inventaire'
 L.CmdShowBank = 'Affiche ou cache votre banque'
 L.CmdShowGuild = 'Affiche ou cache votre banque de guilde'
@@ -22,10 +22,15 @@ L.CmdShowVersion = 'Affiche la version actuelle'
 L.CmdShowOptions = 'Ouvre le menu de configuration'
 L.Updated = 'Mise à jour vers la v%s'
 
---frames
+--frame titles
 L.TitleBags = 'Inventaire |2 %s'
 L.TitleBank = 'Banque |2 %s'
 L.TitleVault = 'Chambre du Vide |2 %s'
+
+--dropdowns
+L.TitleFrames = '%s Fenêtres'
+L.SelectCharacter = 'Choisir Personnage'
+L.ConfirmDelete = 'Etes-vous sur de vouloir supprimer le cache de %s ?'
 
 --interactions
 L.Click = 'Cliquez'
@@ -36,37 +41,44 @@ L.DoubleClick = '<Double Clic>'
 L.ShiftClick = '<Shift+Clic>'
 
 --tooltips
-L.TipChangePlayer = '%s pour afficher les objets d\'un autre personnage.'
-L.TipCleanBags = '%s pour ranger vos sacs.'
-L.TipCleanBank = '%s pour ranger votre banque.'
-L.TipDepositReagents = '%s pour déposer tous les composants.'
-L.TipFrameToggle = '%s pour afficher d\'autres fenêtres.'
+L.Total = 'Total'
+L.GuildFunds = 'Fonds de Guilde'
 L.TipGoldOnRealm = '%s Totals'
+L.NumWithdraw = '%d |4retrait:retraits;'
+L.NumDeposit = '%d |4dépôt:dépôts;'
+L.NumRemainingWithdrawals = '%d Retraits Restant'
+
+--action tooltips
+L.TipChangePlayer = '%s pour afficher les objets d\'un autre personnage.'
+L.TipCleanItems = 'Tri automatique'
+L.TipConfigure = 'Configuration'
+L.TipDepositReagents = '%s pour déposer tous les composants.'
+L.TipDeposit = '%s pour déposer.'
+L.TipWithdraw = '%s pour retirer (%s restant).'
+L.TipFrameToggle = '%s pour afficher d\'autres fenêtres.'
 L.TipHideBag = '%s pour cacher ce sac.'
 L.TipHideBags = '%s pour cacher l\'affichage des sac.'
 L.TipHideSearch = '%s pour cacher le champ de recherche.'
-L.TipResetPlayer = '%s pour retourner sur le personnage actuel.'
+L.TipMove = '%s pour déplacer.'
 L.PurchaseBag = '%s pour acheter cet emplacement de sac.'
+L.TipResetPlayer = '%s pour retourner sur le personnage actuel.'
 L.TipShowBag = '%s pour afficher ce sac.'
 L.TipShowBags = '%s pour afficher la fenêtre de vos sacs.'
 L.TipShowBank = '%s pour afficher/cacher votre banque.'
 L.TipShowInventory = '%s pour afficher/cacher votre inventaire.'
-L.TipShowMenu = '%s pour configurer cette fenêtre.'
 L.TipShowOptions = '%s pour ouvrir le menu des options.'
-L.TipShowSearch = '%s pour rechercher.'
-L.TipShowFrameConfig = '%s pour configurer cette fenêtre.'
-L.TipDeposit = '%s pour déposer.'
-L.TipWithdrawRemaining = '%s pour retirer (%s encore possible).'
-L.TipWithdraw = '%s pour retirer (no remaining).'
-L.NumWithdraw = '%d |4retrait:retraits;'
-L.NumDeposit = '%d |4dépôt:dépôts;'
-L.GuildFunds = 'Guild Funds'
-L.Total = 'Total'
+L.TipShowSearch = 'Rechercher'
 
---itemcount tooltips
-L.TipCountEquip = 'Équipé : %d'
-L.TipCountBags = 'Sacs : %d'
-L.TipCountBank = 'Banque : %d'
-L.TipCountVault = 'Chambre : %d'
-L.TipCountGuild = 'Guilde : %d'
+--item tooltips
+L.TipCountEquip = 'Équipé : %d'
+L.TipCountBags = 'Sacs : %d'
+L.TipCountBank = 'Banque : %d'
+L.TipCountVault = 'Chambre : %d'
+L.TipCountGuild = 'Guilde : %d'
 L.TipDelimiter = '|'
+
+--dialogs
+L.AskMafia = 'Demander à la Mafia'
+L.ConfirmTransfer = 'Déposer un objet retirera toute modification et le rendra non échangeable et non remboursable.|n|nVoulez-vous continuer?'
+L.CannotPurchaseVault = 'Pas assez d\'or pour débloquer la Chambre du Vide|n|n|cffff2020Cost: %s|r'
+L.PurchaseVault = 'Souhaitez-vous débloquer la Banque du Chambre?|n|n|cffffd200Cost:|r %s'


### PR DESCRIPTION
I installed Bagnon on Wrath Classic and saw a few missing french translations.

This PR:
 - Reorganises fr.lua files to look like en.lua
 - Adds the missing translations
 - Updates a few old translations

I'm not sure what `LeftTabs` does, and couldn't find an appropriate translation without more context. I commented out the block for now, it remains untranslated.