### PR TITLE
Proposed fix for Pawn upgrade arrow issues

### DIFF
--- a/core/classes/item.lua
+++ b/core/classes/item.lua
@@ -221,7 +221,12 @@ function Item:UpdateSearch()
 end
 
 function Item:UpdateUpgradeIcon()
-	self.UpgradeIcon:SetShown(self:IsUpgrade())
+	local isUpgrade = self:IsUpgrade()
+	if isUpgrade == nil then
+		self:Delay(0.5, 'UpdateUpgradeIcon')
+	else
+		self.UpgradeIcon:SetShown(isUpgrade)
+	end
 end
 
 function Item:UpdateNewItemAnimation()
@@ -307,7 +312,7 @@ function Item:GetQuery()
 end
 
 function Item:IsUpgrade()
-	return self.hasItem and IsAddOnLoaded('Pawn') and PawnShouldItemLinkHaveUpgradeArrow(self.info.hyperlink)
+	return (self.hasItem or false) and IsAddOnLoaded('Pawn') and PawnShouldItemLinkHaveUpgradeArrow(self.info.hyperlink)
 end
 
 function Item:GetInventorySlot()


### PR DESCRIPTION
Hi! People who use the latest versions of Bagnon and Pawn together are seeing a problem where sometimes their items don't get upgrade arrows when they should. I think there are a couple of problems:

1. The BagBrother version of `Item:UpdateUpgradeIcon` is missing the retry functionality that was there in the Wildpants version. That's still necessary because the item data might not be available yet. Also, in new versions of Pawn, item update queries start returning `nil` for a moment if they start to impact the framerate more than 2 FPS. (You'd mostly see that on Classic versions or slow PCs.)
2. `Item:IsUpgrade` appears to have a bug where it returns `nil` if `self.hasItem` is `nil`, but it should return `false` since `nil` and `false` have different meanings for upgrades. (Without this fix, upgrade arrows get left over in the empty slot when you move an item with an arrow.)

My apologies for not trying Bagnon out after I made that Pawn change! I hope this helps.