### PR TITLE
Bugfix - itemGroup.lua - Items will Flash again on alt + leftButton

### DIFF
--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -68,9 +68,9 @@ end
 
 function Items:FLASH_ITEM(_,itemID)
 	for i, button in ipairs(self.order) do
-		self.Flash:Stop()
+		button.Flash:Stop()
 		if button.info.itemID == itemID then
-			self.Flash:Play()
+			button.Flash:Play()
 		end
 	end
 end


### PR DESCRIPTION
Items were not flashing when using alt + LeftButton combination. I fixed this issue locally and also tested it properly.