### PR TITLE
Implementation of Empty Bags Slot Visibility Control

### DIFF
--- a/config/localization/cn.lua
+++ b/config/localization/cn.lua
@@ -48,6 +48,7 @@ L.Layer = '层级'
 L.BagBreak = '背包分散'
 L.ReverseBags = '反向背包排列'
 L.ReverseSlots = '反向物品排列'
+L.HideEmptySlot = '隐藏空槽'
 
 L.Color = '背景颜色'
 L.BorderColor = '边框颜色'

--- a/config/localization/de.lua
+++ b/config/localization/de.lua
@@ -35,6 +35,7 @@ L.Layer = 'Ebene'
 L.BagBreak = 'Trennen der Taschen aktivieren'
 L.ReverseBags = 'Taschen umkehren'
 L.ReverseSlots = 'Slots umkehren'
+L.HideEmptySlot = 'Leere Plätze verbergen'
 
 L.Color = 'Farbe des Fensters'
 L.BorderColor = 'Farbe des Fensterrands'

--- a/config/localization/en.lua
+++ b/config/localization/en.lua
@@ -48,6 +48,7 @@ L.Layer = 'Layer'
 L.BagBreak = 'Bag Break'
 L.ReverseBags = 'Reverse Bag Order'
 L.ReverseSlots = 'Reverse Slot Order'
+L.HideEmptySlot = 'Hide empty slots'
 
 L.Color = 'Background Color'
 L.BorderColor = 'Border Color'

--- a/config/localization/es.lua
+++ b/config/localization/es.lua
@@ -47,6 +47,7 @@ L.Layer = 'Capa'
 L.BagBreak = 'Espacio entre bolsas'
 L.ReverseBags = 'Invertir bolsas'
 L.ReverseSlots = 'Invertir ranuras'
+L.HideEmptySlot = 'Ocultar espacios vacíos'
 
 L.Color = 'Color de fondo'
 L.BorderColor = 'Color de borde'

--- a/config/localization/fr.lua
+++ b/config/localization/fr.lua
@@ -47,6 +47,7 @@ L.Layer = 'Couche'
 L.BagBreak = 'Séparation entre les sacs'
 L.ReverseBags = 'Inverser ordre des sacs'
 L.ReverseSlots = 'Inverser ordre de tri'
+L.HideEmptySlot = 'Cacher les emplacements vides'
 
 L.Color = 'Couleur de la fenêtre'
 L.BorderColor = 'Couleur de bordure'

--- a/config/localization/it.lua
+++ b/config/localization/it.lua
@@ -46,6 +46,7 @@ L.Layer = 'Livello'
 L.BagBreak = 'Separazione tra Borse'
 L.ReverseBags = 'Inverti le Borse'
 L.ReverseSlots = 'Inverti gli Scomparti'
+L.HideEmptySlot = 'Nascondi gli spazi vuoti'
 
 L.Color = 'Colore della Finestra'
 L.BorderColor = 'Colore del Bordo'

--- a/config/localization/ko.lua
+++ b/config/localization/ko.lua
@@ -46,6 +46,7 @@ L.Layer = '레이어'
 L.BagBreak = '가방 별로 구분하여 표시'
 L.ReverseBags = '가방 순서 반대로'
 L.ReverseSlots = '칸 순서 반대로'
+L.HideEmptySlot = '빈 슬롯 숨기기'
 
 L.Color = '배경 색상'
 L.BorderColor = '테두리 색상'

--- a/config/localization/nl.lua
+++ b/config/localization/nl.lua
@@ -49,6 +49,7 @@ L.Layer = 'Laag'
 L.BagBreak = 'Tas Onderbreken'
 L.ReverseBags = 'Omgekeerde Tasvolgorde'
 L.ReverseSlots = 'Omgekeerde Slotvolgorde'
+L.HideEmptySlot = 'Verberg lege plaatsen'
 
 L.Color = 'Achtergrondkleur'
 L.BorderColor = 'Randkleur'

--- a/config/localization/pt.lua
+++ b/config/localization/pt.lua
@@ -44,6 +44,8 @@ L.Layer = 'Camada'
 L.BagBreak = 'Quebras entre Sacos'
 L.ReverseBags = 'Inverter Sacos'
 L.ReverseSlots = 'Inverter Itens'
+L.HideEmptySlot = 'Ocultar espaços vazios'
+
 L.Color = 'Cor de Fundo'
 L.BorderColor = 'Cor do Bordo'
 L.Strata = 'Camada'

--- a/config/localization/ru.lua
+++ b/config/localization/ru.lua
@@ -45,6 +45,7 @@ L.Layer = 'Слой'
 L.BagBreak = 'Каждая сумка с новой строки'
 L.ReverseBags = 'Обратный порядок сумок'
 L.ReverseSlots = 'Обратный порядок ячеек'
+L.HideEmptySlot = 'Скрыть пустые слоты'
 
 L.Color = 'Цвет фона окна'
 L.BorderColor = 'Цвет границы окна'

--- a/config/localization/tw.lua
+++ b/config/localization/tw.lua
@@ -37,6 +37,7 @@ L.Layer = '階層'
 L.BagBreak = '根據背包顯示'
 L.ReverseBags = '反轉背包順序'
 L.ReverseSlots = '反轉槽位順序'
+L.HideEmptySlot = '隱藏空槽'
 
 L.Color = '背景顏色'
 L.BorderColor = '邊框顏色'

--- a/config/panels/frameOptions.lua
+++ b/config/panels/frameOptions.lua
@@ -11,6 +11,7 @@ local Frames = Addon.GeneralOptions:New('FrameOptions', CreateAtlasMarkup('Vehic
 function Frames:Populate()
   -- Selection
   self.sets = Addon.player.profile[self.frame]
+
   self:AddFrameChoice()
 
   local enabled = Addon.Frames:IsEnabled(self.frame)
@@ -58,7 +59,7 @@ function Frames:Populate()
 
 		-- Appearance
 		self:Add('Header', L.Appearance, 'GameFontHighlight', true)
-		self:AddRow(70, function()
+		self:AddRow(90, function()
 			if Config.colors then
 				self:AddColor('color')
 				self:AddColor('borderColor')
@@ -71,6 +72,7 @@ function Frames:Populate()
 			if REAGENTBANK_CONTAINER and self.frame == 'bank' then
 				self:AddCheck('exclusiveReagent')
 			end
+
 		end)
 
     self:AddRow(150, function()
@@ -83,6 +85,9 @@ function Frames:Populate()
       if Config.columns then
         self:AddSlider('columns', 1, 50)
       end
+        if self.frame == 'inventory'then
+            self:AddChoice{arg = 'HideEmptySlot',{key='NONE',text = NONE} ,{key = 'BAG', text = INVTYPE_BAG }, {key = 'KEYRING', text = KEYRING},{key = 'BOTH', text = STATUS_TEXT_BOTH }}
+        end
     end)
   end
 end

--- a/core/classes/frameBase.lua
+++ b/core/classes/frameBase.lua
@@ -98,13 +98,26 @@ end
 function Frame:IsShowingItem(bag, slot)
 	local info = self:GetItemInfo(bag, slot)
 	local rule = Addon.Rules:Get(self.subrule or self.rule)
-
+	local profile = self:GetProfile()
+	local bagName =C_Container.GetBagName(bag)
+	local itemType, itemSubType
+	if bagName then
+		_, _, _, _, _, itemType, itemSubType= GetItemInfo(bagName)
+	end
 	if rule and rule.func then
 		if not rule.func(self.owner, bag, slot, self:GetBagInfo(bag), info) then
 			return
 		end
 	end
-
+	if info.itemID == nil then -- if itemID is nil, then it is an empty slot
+		if profile.HideEmptySlot == 'BAG' and (itemSubType == INVTYPE_BAG or bagName ~= nil)  then --bagName ~= nil is for the backpack
+			return
+		elseif profile.HideEmptySlot == 'KEYRING' and bagName == nil then -- if bagName is nil, then it is the keyring
+			return
+		elseif profile.HideEmptySlot == 'BOTH' then
+			return
+		end
+	end
 	return self:IsShowingQuality(info.quality)
 end
 

--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -99,9 +99,8 @@ function Items:Layout()
 	end
 
 	-- Position slots
-	local profile = self:GetProfile()
 	local columns, scale, size = self:LayoutTraits()
-
+	local profile = self:GetProfile()
 	local revBags, revSlots = profile.reverseBags, profile.reverseSlots
 	local x, y = 0,0
 
@@ -127,7 +126,8 @@ function Items:Layout()
 				end
 			end
 
-			if self:GetProfile().bagBreak and x > 0 then
+
+			if profile.bagBreak and x > 0 then
 				y = y + 1
 				x = 0
 			end


### PR DESCRIPTION
## Summary
This pull request implements the functionality to control the visibility of empty slots in bags based on user settings.

## Changes Implemented
- Implemented a new setting for controlling the visibility of empty slots.
- Updated the `Frame:IsShowingItem(bag, slot)` function to handle the display logic of empty slots based on the new setting.

## How to Test
1. Navigate to the BrotherBags options.
2. Locate the new setting for empty bags slot visibility.
3. Toggle the setting to None, Bag, Keyring or both.
4. Verify that the empty slots are hidden based on the setting.



## Additional Information
- Related Issue: [#1436](https://github.com/Jaliborc/Bagnon/issues/1436)
