### PR TITLE
Fixed addon compartment name and icon

### DIFF
--- a/core/core.lua
+++ b/core/core.lua
@@ -42,8 +42,8 @@ function Addon:OnEnable()
 	(SettingsPanel or InterfaceOptionsFrame):HookScript('OnShow', function() C.LoadAddOn(ADDON .. '_Config') end)
 	if AddonCompartmentFrame then
 		AddonCompartmentFrame:RegisterAddon {
-			text = 'Scrap', keepShownOnClick = true, notCheckable = true,
-			icon = 'interface/addons/bagnon/art/bagnon-small',
+			text = 'Bagnon', keepShownOnClick = true, notCheckable = true,
+			icon = 'interface/addons/bagbrother/art/bagnon-small',
 			func = function() self:ShowOptions() end
 		}
 	end


### PR DESCRIPTION
Fixes the addon compartment name and icon path.  Since this codebase is shared between Bagnon and Bagnonium, I don't know if there's a way to dynamically set these values, but this should be an improvement.