### PR TITLE
Fix for 1939 - profile.bagBreak is a boolean now

### DIFF
--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -109,7 +109,7 @@ function Items:Layout()
 			local family = self.frame:GetBagFamily(bag)
 			local slots = {}
 
-			if x > 0 and (profile.bagBreak > 1 or profile.bagBreak > 0 and family ~= group and family * group <= 0) then
+			if x > 0 and (profile.bagBreak and family ~= group and family * group <= 0) then
 				group = family
 				y = y + space
 				x = 0


### PR DESCRIPTION
The `profile.bagBreak` appears to be a `boolean` value now which is the cause of an error when the Bagnon plugin is loaded initially into WoW v11.0.2.

The Jaliborc/Bagnon#1939 issue that was reported would be resolved with this fix.  Or at least the error stops and the Bagnon bag addon appears to be working as expected.