### PR TITLE
Fix currency display quantities

### DIFF
--- a/core/features/caching.lua
+++ b/core/features/caching.lua
@@ -90,7 +90,7 @@ end
 
 function Cacher:CURRENCY_DISPLAY_UPDATE(_, id, quantity)
 	if id and quantity and not C.CurrencyInfo.IsAccountWideCurrency(id) then
-		local displayInfo = C_CurrencyInfo.GetBasicCurrencyInfo(id, quantity or 0)
+		local displayInfo = C.CurrencyInfo.GetBasicCurrencyInfo(id, quantity or 0)
 		local displayQuantity = displayInfo.displayAmount > 0 and displayInfo.displayAmount or nil
 		self.player.currency[id] = displayQuantity
 	end

--- a/core/features/caching.lua
+++ b/core/features/caching.lua
@@ -90,7 +90,9 @@ end
 
 function Cacher:CURRENCY_DISPLAY_UPDATE(_, id, quantity)
 	if id and quantity and not C.CurrencyInfo.IsAccountWideCurrency(id) then
-		self.player.currency[id] = quantity > 0 and quantity or nil
+		local displayInfo = C_CurrencyInfo.GetBasicCurrencyInfo(id, quantity or 0)
+		local displayQuantity = displayInfo.displayAmount > 0 and displayInfo.displayAmount or nil
+		self.player.currency[id] = displayQuantity
 	end
 end
 

--- a/core/features/caching.lua
+++ b/core/features/caching.lua
@@ -88,11 +88,12 @@ function Cacher:PLAYER_MONEY()
 	self.player.money = GetMoney()
 end
 
-function Cacher:CURRENCY_DISPLAY_UPDATE(_, id, quantity)
-	if id and quantity and not C.CurrencyInfo.IsAccountWideCurrency(id) then
-		local displayInfo = C.CurrencyInfo.GetBasicCurrencyInfo(id, quantity or 0)
-		local displayQuantity = displayInfo.displayAmount > 0 and displayInfo.displayAmount or nil
-		self.player.currency[id] = displayQuantity
+function Cacher:CURRENCY_DISPLAY_UPDATE(_, id)
+	if id and not C.CurrencyInfo.IsAccountWideCurrency(id) then
+		local info = C.CurrencyInfo.GetCurrencyInfo(id)
+		if info then
+			self.player.currency[id] = info.quantity
+		end
 	end
 end
 


### PR DESCRIPTION
Some currencies (mainly PvP currencies like Conquest or Bloody Tokens) have an assumed precision on the API side. The actual stored quantity will be 5000 but the value displayed to the player in all scenarios will be 50.

I don't think `GetBasicCurrencyInfo` is included in `C_Everywhere` so this likely needs more work before it can just be merged, but I wanted to propose a potential fix that we can work on together. I'm happy to look at adding the function to `C_Everywhere` library as well.