### PR TITLE
fixing duplicate upgrade icon after sorting

### DIFF
--- a/core/classes/item.lua
+++ b/core/classes/item.lua
@@ -205,6 +205,7 @@ end
 function Item:UpdateUpgradeIcon()
 	local isUpgrade = self:IsUpgrade()
 	if isUpgrade == nil then
+		self.UpgradeIcon:SetShown(false)
 		self:Delay(0.5, 'UpdateUpgradeIcon')
 	else
 		self.UpgradeIcon:SetShown(isUpgrade)


### PR DESCRIPTION
When you use Pawn for showing Item Upgrades and you swap an upgrade item with another item the upgrade arrow will be shown on both items.

This PR fixes this problem.