### PR TITLE
Adjusted getting MoneyFrame UpdateFunc to latest client api

### DIFF
--- a/core/classes/playerMoney.lua
+++ b/core/classes/playerMoney.lua
@@ -45,7 +45,7 @@ function Money:Construct()
 	overlay:RegisterForClicks('anyUp')
 	overlay:SetAllPoints()
 
-	f.info = MoneyTypeInfo[f.Type]
+	f.updateFunc = GetMoneyTypeInfoField(f.Type, "UpdateFunc")
 	f.overlay = overlay
 	return f
 end
@@ -71,13 +71,13 @@ function Money:OnClick()
 
 	local name = self:GetName()
 	if MouseIsOver(_G[name .. 'GoldButton']) then
-		OpenCoinPickupFrame(COPPER_PER_GOLD, self.info.UpdateFunc(self), self)
+		OpenCoinPickupFrame(COPPER_PER_GOLD, self.updateFunc(self), self)
 		self.hasPickup = 1
 	elseif MouseIsOver(_G[name .. 'SilverButton']) then
-		OpenCoinPickupFrame(COPPER_PER_SILVER, self.info.UpdateFunc(self), self)
+		OpenCoinPickupFrame(COPPER_PER_SILVER, self.updateFunc(self), self)
 		self.hasPickup = 1
 	elseif MouseIsOver(_G[name .. 'CopperButton']) then
-		OpenCoinPickupFrame(1, self.info.UpdateFunc(self), self)
+		OpenCoinPickupFrame(1, self.updateFunc(self), self)
 		self.hasPickup = 1
 	end
 


### PR DESCRIPTION
In builds 11.1.0.60189, 4.4.2.60192 and 1.15.7.60191 blizzard made MoneyTypeInfo local to MoneyFrame.lua and exposed GetMoneyTypeInfoField instead

Replaces crude workaround from #73