### PR TITLE
use first bottom and side filters initially every session

### DIFF
--- a/core/classes/tabGroup.lua
+++ b/core/classes/tabGroup.lua
@@ -15,7 +15,7 @@ function Tabs:New(parent, id)
 	f.rules = f.frame.profile.rules[id]
 	f.id, f.buttons = id, {}
 
-	f:SetActive(Addon.Rules:Get('all'))
+	f:SetActive(Addon.Rules:Get(f.rules[1]))
 	f:RegisterFrameSignal('FILTERS_CHANGED', 'Update')
 	f:RegisterFrameSignal('OWNER_CHANGED', 'Update')
 	f:RegisterSignal('RULES_LOADED', 'Update')


### PR DESCRIPTION
Should be safe to just use f.rules[1] since the UI prevents the user from picking no filters at all for bottom or side tabs, so the only way this could cause an error is if someone would manually edit the Bagnonium.lua SavedVariables that define those rules to delete them all.