### PR TITLE
fix(playerMoney): bug with displaying guild gold

### DIFF
--- a/core/classes/playerMoney.lua
+++ b/core/classes/playerMoney.lua
@@ -91,7 +91,7 @@ function Money:OnEnter()
 
 	local total, overflow = 0, 0
 	for i, owner in Addon.Owners:Iterate() do
-		local money = not owner.isguild and owner:GetMoney()
+		local money = owner.isguild and nil or owner:GetMoney()
 		if money and i <= 8 or owner.favorite then
 			local coins = GetMoneyString(money, true)
 			local icon = owner:GetIconMarkup(12,0,0)


### PR DESCRIPTION
wow classic 20th anniversary

annoying lua errors on mouse enter player gold

Message: ...terface/AddOns/Blizzard_SharedXML/FormattingUtil.lua:64: attempt to perform arithmetic on local 'money' (a boolean value)
Time: Sat Aug 23 02:07:31 2025
Count: 1
Stack:
[Interface/AddOns/Blizzard_SharedXML/FormattingUtil.lua]:64: in function 'GetMoneyString'
[Interface/AddOns/BagBrother/core/classes/playerMoney.lua]:96: in function 'OnEnter'
[Interface/AddOns/BagBrother/core/classes/playerMoney.lua]:43: in function <...rface/AddOns/BagBrother/core/classes/playerMoney.lua:43>
Locals:
money = false
separateThousands = true
checkGoldThreshold = nil
goldString = nil
silverString = nil
copperString = nil
(temporary) = 10000
(temporary) = 100
(temporary) = nil
(temporary) = nil
(temporary) = nil
(temporary) = nil
(temporary) = nil
(temporary) = "attempt to perform arithmetic on local 'money' (a boolean value)"
COPPER_PER_SILVER = 100
SILVER_PER_GOLD = 100