### PR TITLE
fix(bag): issue with toggle keyring when player has keys

### DIFF
--- a/core/classes/bag.lua
+++ b/core/classes/bag.lua
@@ -167,6 +167,11 @@ end
 
 function Bag:Toggle()
 	local data = self.frame:GetBagInfo(self:GetID())
+
+	if not data then
+		return
+	end
+
 	data.hidden = not data.hidden
 
 	PlaySound(data.hidden and 856 or 857)


### PR DESCRIPTION
wow classic 20th anniversary

lua error started appearing when i got 1st key. also it left keyring always opened and unable to toggle

Message: Interface/AddOns/BagBrother/core/classes/bag.lua:170: attempt to index local 'data' (a nil value)
Time: Sun Aug 24 17:30:39 2025
Count: 3
Stack:
[Interface/AddOns/BagBrother/core/classes/bag.lua]:170: in function 'Toggle'
[Interface/AddOns/BagBrother/core/classes/bag.lua]:127: in function <Interface/AddOns/BagBrother/core/classes/bag.lua:123>
Locals:
self = CheckButton {
 icon = "interface/containerframe/keyring-bag-icon"
 Count = FontString {
 }
 slot = false
 owned = true
 frame = BagnonInventory1 {
 }
 Icon = Texture {
 }
 FilterIcon = Frame {
 }
}
data = nil
(temporary) = BagnonInventory1 {
 rules = <table> {
 }
 SearchBar = EditBox {
 }
 manualShown = true
 BrokerCarrousel = Button {
 }
 inset = 0
 Title = Button {
 }
 BagGroup = Frame {
 }
 skin = Frame {
 }
 margin = 0
 BagToggle = CheckButton {
 }
 OwnerSelector = Button {
 }
 icon = 130716
 SearchToggle = CheckButton {
 }
 MoneyFrame = BagnonPlayerMoney1 {
 }
 ItemGroup = Frame {
 }
 id = "inventory"
 SortButton = CheckButton {
 }
 CurrencyTracker = Frame {
 }
 profile = <table> {
 }
 CloseButton = Button {
 }
 compiled = <table> {
 }
 Footer = Frame {
 }
 OptionsToggle = Button {
 }
 focusedBag = -2
 MenuButtons = <table> {
 }
 name = "Inventory"
}
(temporary) = -2
(temporary) = nil
(temporary) = "attempt to index local 'data' (a nil value)"