### PR TITLE
Fix money tooltip

### DIFF
--- a/core/classes/playerMoney.lua
+++ b/core/classes/playerMoney.lua
@@ -93,7 +93,7 @@ function Money:OnEnter()
 	for _, owner in Addon.Owners:Iterate() do
 		local money = not owner.isguild and owner:GetMoney()
 		if money and money > 0 then
-			tinsert(liquid, {owner: owner, money: money})
+			tinsert(liquid, {['owner'] = owner, ['money'] = money})
 		end
 	end
 
@@ -102,8 +102,8 @@ function Money:OnEnter()
 	end)
 
 	local total, overflow = 0, 0
-	for _, entry in ipairs(liquid) do
-		local owner, money = entry.onwer, entry.money
+	for i, entry in ipairs(liquid) do
+		local owner, money = entry.owner, entry.money
 		if i <= 10 or owner.favorite then
 			local coins = GetMoneyString(money, true, true)
 			local icon = owner:GetIconMarkup(12,0,0)


### PR DESCRIPTION
With the release of 12.0.8, certain errors were introduced when running BagBrother on TBC Anniversary (Game Version 2.5.5, Interface 20505).

Upon entering the world, the following Lua error would occur and the bag interface would not load at all:

> Interface/AddOns/BagBrother/core/classes/playerMoney.lua:96: function arguments expected near ','

The issue seems to be that `owner` is an object and cannot be used as an unquoted key for the table. Using the alternative `['owner'] =` syntax seems to work as expected.

Additionally, there seemed to be 2 issues on line 107:

1. We are checking `if i <= 10`, however `i` was never set, but discarded as `_` in the `ipairs` for loop.
2. There was a typo `entry.onwer` instead of `entry.owner`.

Addressing these two issues seems to fix the tooltip as expected.

<img width="245" height="177" alt="image" src="https://github.com/user-attachments/assets/6f869f9a-2baa-44d6-b0db-933ecfc237d7" />
