### PR TITLE
Optimize sorting: minimize item moves and keep identical items in-place

### DIFF
--- a/.agents/rules/bagbrother_maintenance_rules.md
+++ b/.agents/rules/bagbrother_maintenance_rules.md
@@ -50,6 +50,10 @@ To maintain codebase consistency and compatibility, all changes must follow thes
 
 ## 3. Testing and Verification
 
+*   **Syntax Check:** Before committing, run `luac -p` on all modified or new Lua files to ensure there are no syntax errors:
+    ```bash
+    luac -p path/to/file.lua
+    ```
 *   **In-Game Verification:** Automated CLI test suites are not supported. All logic and layout changes must be manually verified inside the World of Warcraft client.
 *   **Error Reporting:** Enable script error displays during development:
     ```

--- a/.agents/rules/bagbrother_maintenance_rules.md
+++ b/.agents/rules/bagbrother_maintenance_rules.md
@@ -1,0 +1,72 @@
+# BagBrother Maintenance & Development Rules
+
+This document outlines the architecture, coding standards, testing procedures, and rules for maintaining and contributing to the **BagBrother** addon codebase.
+
+---
+
+## 1. Codebase Architecture & Structure
+
+BagBrother serves as the backend engine, database cache, and core component library for both Bagnon and Bagnonium addons.
+
+*   **/core**: The main backend logic.
+    *   `/api`: Common interfaces for events, settings, frames, filters (rules), skinning, and sorting.
+    *   `/classes`: Base UI components (item slots, bag slots, money frames, tabs) using the Poncho OOP model.
+    *   `/features`: System features such as cross-character inventory/currency caching, tooltips, and slash commands.
+    *   `/localization`: Localization dictionaries.
+*   **/frames**: Specific layouts and views for the four main UI interfaces:
+    *   `/inventory`: Character bags.
+    *   `/bank`: Bank slots, reagent bank, and account-wide warband banks.
+    *   `/guild`: Guild vaults/banks and log tabs.
+    *   `/vault`: Character void storage.
+*   **/libs**: External library modules linked as Git submodules. Crucial shared utility libraries include `Poncho-2.0`, `Sushi-3.2`, `C_Everywhere`, `MutexDelay-1.0`, and `ItemSearch-1.3`.
+
+---
+
+## 2. Formatting & Development Rules
+
+To maintain codebase consistency and compatibility, all changes must follow these guidelines:
+
+### Indentation and Formatting
+*   **Use Tabs:** Use tabs (`\t`) for indentation. Do not mix spaces and tabs.
+*   **Whitespace:** Keep clean spacing around logical conditions and functions.
+
+### File Registrations & Load Order
+*   **XML Manifests:** WoW client load ordering is strictly managed via nested XML manifests. 
+    *   Do not list new `.lua` files in `.toc` files directly.
+    *   Always register new scripts in the appropriate local XML manifest (e.g., `core/api/api.xml`, `core/classes/classes.xml`, or `frames/bank/bank.xml`) using the `<Script file="filename.lua"/>` tag.
+
+### Multi-Expansion Support
+*   BagBrother supports Mainline (Retail), Cataclysm Classic, and Vanilla Classic.
+*   **Avoid Raw Version-Specific API Calls:** Use the unified wrapper library **C_Everywhere** (`LibStub('C_Everywhere')`) to bridge expansion API gaps.
+*   **Conditional Checks:** Use flags like `Addon.IsRetail`, `Addon.IsClassic`, or expansion level constants to guard version-specific features.
+
+### Class and OOP Definitions
+*   Always inherit from the Poncho-2.0 base class when creating new components:
+    ```lua
+    local Base = Addon:NewModule('ClassName', LibStub('Poncho-2.0')())
+    ```
+
+---
+
+## 3. Testing and Verification
+
+*   **In-Game Verification:** Automated CLI test suites are not supported. All logic and layout changes must be manually verified inside the World of Warcraft client.
+*   **Error Reporting:** Enable script error displays during development:
+    ```
+    /console scriptErrors 1
+    ```
+    (Using error catching addons like *BugSack* & *BugGrabber* is highly recommended).
+*   **Unit Tests:** Unit tests for shared libraries (submodules under `libs/`) are defined in `Tests.lua` files. These run in-game using the **WoWUnit** addon.
+*   **SavedVariables Migrations:** When updating data cache patterns (like `BrotherBags`), always verify that schema updates are safely migrated in `Settings:Upgrade` within `core/api/settings.lua`.
+
+---
+
+## 4. Release Packaging & Submodules
+
+*   **Git Submodules:** Keep all submodules in sync. Before committing or building, verify submodules are initialized and updated recursively:
+    ```bash
+    git submodule update --init --recursive
+    ```
+*   **Release Packaging (`.upconfig`):**
+    *   The release package is generated automatically using the BigWigsMods WoW packager.
+    *   Any test files, visual mockup assets, or source files that should be ignored during packaging must be specified under the `[ignore]` block in `.upconfig` in the root directory.

--- a/core/api/sorting.lua
+++ b/core/api/sorting.lua
@@ -37,6 +37,7 @@ end
 function Sort:Iterate()
 	local spaces = self:GetSpaces()
 	local families = self:GetFamilies(spaces)
+	local isThrottled = self.target.id == 'guild' or self.target.id == 'vault'
 
 	local stackable = function(item)
 		return (item.stackCount or 1) < (item.stackSize or 1)
@@ -50,8 +51,12 @@ function Sort:Iterate()
 				local other = from.item
 
 				if item.itemID == other.itemID and stackable(other) then
-					self:Move(from, target)
-					self:Delay(0.05, 'Run')
+					if self:Move(from, target) then
+						self:Delay(0.05, 'Run')
+						if isThrottled then
+							return
+						end
+					end
 				end
 			end
 		end
@@ -65,12 +70,14 @@ function Sort:Iterate()
 		local order, spaces = self:GetOrder(spaces, family)
 		local n = min(#order, #spaces)
 
+		self:OptimizeOrder(order, spaces, n)
+
 		for index = 1, n do
 			local goal = spaces[index]
 			local item = order[index]
 			item.sorted = true
 
-			if item.space ~= goal then
+			if item.space ~= goal and not (goal.item.itemID == item.itemID and goal.item.stackCount == item.stackCount) then
 				local distance = moveDistance(item, goal)
 
 				for j = index, n do
@@ -84,8 +91,12 @@ function Sort:Iterate()
 					end
 				end
 
-				self:Move(item.space, goal)
-				self:Delay(0.05, 'Run')
+				if self:Move(item.space, goal) then
+					self:Delay(0.05, 'Run')
+					if isThrottled then
+						return
+					end
+				end
 			end
 		end
 	end
@@ -175,6 +186,69 @@ function Sort:GetOrder(spaces, family)
 
 	sort(order, self.Rule)
 	return order, slots
+end
+
+function Sort:OptimizeOrder(order, spaces, n)
+	local groups = {}
+	for i = 1, n do
+		local item = order[i]
+		if item.itemID then
+			local key = item.itemID .. '_' .. (item.stackCount or 1)
+			if not groups[key] then
+				groups[key] = {}
+			end
+			tinsert(groups[key], i)
+		end
+	end
+
+	for key, indices in pairs(groups) do
+		if #indices > 1 then
+			local items = {}
+			local targetSlots = {}
+			for _, idx in ipairs(indices) do
+				items[idx] = order[idx]
+				targetSlots[spaces[idx]] = idx
+			end
+
+			local matchedItems = {}
+			local matchedSlots = {}
+
+			for idx, item in pairs(items) do
+				local targetIdx = targetSlots[item.space]
+				if targetIdx and not matchedSlots[targetIdx] then
+					matchedItems[idx] = targetIdx
+					matchedSlots[targetIdx] = idx
+				end
+			end
+
+			local remainingIdx = {}
+			for _, idx in ipairs(indices) do
+				if not matchedItems[idx] then
+					tinsert(remainingIdx, idx)
+				end
+			end
+
+			local remainingTargets = {}
+			for _, idx in ipairs(indices) do
+				if not matchedSlots[idx] then
+					tinsert(remainingTargets, idx)
+				end
+			end
+
+			for i = 1, #remainingIdx do
+				matchedItems[remainingIdx[i]] = remainingTargets[i]
+			end
+
+			local temp = {}
+			for srcIdx, destIdx in pairs(matchedItems) do
+				temp[destIdx] = items[srcIdx]
+			end
+
+			for _, idx in ipairs(indices) do
+				order[idx] = temp[idx]
+			end
+		end
+	end
 end
 
 


### PR DESCRIPTION
This PR introduces optimizations to the client-side sorting algorithm (sorting.lua) to reduce the total number of moves/swaps required to sort bags, which is particularly beneficial in lag-sensitive environments like the Guild Bank:

- Identical Item Matching (OptimizeOrder): Identical items (same itemID and stackCount) are matched to target slots so that any item already sitting in a valid target slot remains in-place. This minimizes cycles and prevents redundant swaps.
- Skip Redundant Swaps: Moves are skipped if the target slot already contains an identical item.
- Throttled Moves for Server-Bound Containers: To prevent server-side transaction drops/failures in the Guild Bank and Void Storage (which strictly rate-limit operations), the algorithm now returns early after initiating a move on these specific containers (detected via self.target.id == 'guild' or 'vault'). This limits them to 1 move per tick (50ms), while allowing character bags and the normal bank to continue sorting instantly in a single tick as before.