### PR TITLE
Optimize sorting: minimize moves and keep identical items in-place

### DIFF
--- a/core/api/sorting.lua
+++ b/core/api/sorting.lua
@@ -62,9 +62,6 @@ function Sort:Iterate()
 		end
 	end
 
-	local moveDistance = function(item, goal)
-		return math.abs(item.space.index - goal.index)
-	end
 
 	for _, family in ipairs(families) do
 		local order, spaces = self:GetOrder(spaces, family)
@@ -78,19 +75,6 @@ function Sort:Iterate()
 			item.sorted = true
 
 			if item.space ~= goal and not (goal.item.itemID == item.itemID and goal.item.stackCount == item.stackCount) then
-				local distance = moveDistance(item, goal)
-
-				for j = index, n do
-					local other = order[j]
-					if other.itemID == item.itemID and other.stackCount == item.stackCount then
-						local d = moveDistance(other, spaces[j])
-						if d > distance then
-							item = other
-							distance = d
-						end
-					end
-				end
-
 				if self:Move(item.space, goal) then
 					self:Delay(0.05, 'Run')
 					if isThrottled then

--- a/core/api/sorting.lua
+++ b/core/api/sorting.lua
@@ -189,6 +189,7 @@ function Sort:GetOrder(spaces, family)
 end
 
 function Sort:OptimizeOrder(order, spaces, n)
+	-- Group indices of identical items (same ID and stack count)
 	local groups = {}
 	for i = 1, n do
 		local item = order[i]
@@ -201,6 +202,7 @@ function Sort:OptimizeOrder(order, spaces, n)
 		end
 	end
 
+	-- Optimize matching for each group of identical items
 	for key, indices in pairs(groups) do
 		if #indices > 1 then
 			local items = {}
@@ -213,6 +215,7 @@ function Sort:OptimizeOrder(order, spaces, n)
 			local matchedItems = {}
 			local matchedSlots = {}
 
+			-- Match items that are already in one of their target slots in-place
 			for idx, item in pairs(items) do
 				local targetIdx = targetSlots[item.space]
 				if targetIdx and not matchedSlots[targetIdx] then
@@ -221,6 +224,7 @@ function Sort:OptimizeOrder(order, spaces, n)
 				end
 			end
 
+			-- Collect remaining unmatched items and target slots
 			local remainingIdx = {}
 			for _, idx in ipairs(indices) do
 				if not matchedItems[idx] then
@@ -235,10 +239,12 @@ function Sort:OptimizeOrder(order, spaces, n)
 				end
 			end
 
+			-- Pair up remaining items to remaining target slots
 			for i = 1, #remainingIdx do
 				matchedItems[remainingIdx[i]] = remainingTargets[i]
 			end
 
+			-- Apply the optimized mapping back to the order list
 			local temp = {}
 			for srcIdx, destIdx in pairs(matchedItems) do
 				temp[destIdx] = items[srcIdx]

--- a/core/api/sorting.lua
+++ b/core/api/sorting.lua
@@ -37,6 +37,7 @@ end
 function Sort:Iterate()
 	local spaces = self:GetSpaces()
 	local families = self:GetFamilies(spaces)
+	local isThrottled = self.target.id == 'guild' or self.target.id == 'vault'
 
 	local stackable = function(item)
 		return (item.stackCount or 1) < (item.stackSize or 1)
@@ -50,8 +51,12 @@ function Sort:Iterate()
 				local other = from.item
 
 				if item.itemID == other.itemID and stackable(other) then
-					self:Move(from, target)
-					self:Delay(0.05, 'Run')
+					if self:Move(from, target) then
+						self:Delay(0.05, 'Run')
+						if isThrottled then
+							return
+						end
+					end
 				end
 			end
 		end
@@ -65,12 +70,14 @@ function Sort:Iterate()
 		local order, spaces = self:GetOrder(spaces, family)
 		local n = min(#order, #spaces)
 
+		self:OptimizeOrder(order, spaces, n)
+
 		for index = 1, n do
 			local goal = spaces[index]
 			local item = order[index]
 			item.sorted = true
 
-			if item.space ~= goal then
+			if item.space ~= goal and not (goal.item.itemID == item.itemID and goal.item.stackCount == item.stackCount) then
 				local distance = moveDistance(item, goal)
 
 				for j = index, n do
@@ -84,8 +91,12 @@ function Sort:Iterate()
 					end
 				end
 
-				self:Move(item.space, goal)
-				self:Delay(0.05, 'Run')
+				if self:Move(item.space, goal) then
+					self:Delay(0.05, 'Run')
+					if isThrottled then
+						return
+					end
+				end
 			end
 		end
 	end
@@ -175,6 +186,69 @@ function Sort:GetOrder(spaces, family)
 
 	sort(order, self.Rule)
 	return order, slots
+end
+
+function Sort:OptimizeOrder(order, spaces, n)
+	local groups = {}
+	for i = 1, n do
+		local item = order[i]
+		if item.itemID then
+			local key = item.itemID .. '_' .. (item.stackCount or 1)
+			if not groups[key] then
+				groups[key] = {}
+			end
+			tinsert(groups[key], i)
+		end
+	end
+
+	for key, indices in pairs(groups) do
+		if #indices > 1 then
+			local items = {}
+			local targetSlots = {}
+			for _, idx in ipairs(indices) do
+				items[idx] = order[idx]
+				targetSlots[spaces[idx]] = idx
+			end
+
+			local matchedItems = {}
+			local matchedSlots = {}
+
+			for idx, item in pairs(items) do
+				local targetIdx = targetSlots[item.space]
+				if targetIdx and not matchedSlots[targetIdx] then
+					matchedItems[idx] = targetIdx
+					matchedSlots[targetIdx] = idx
+				end
+			end
+
+			local remainingIdx = {}
+			for _, idx in ipairs(indices) do
+				if not matchedItems[idx] then
+					tinsert(remainingIdx, idx)
+				end
+			end
+
+			local remainingTargets = {}
+			for _, idx in ipairs(indices) do
+				if not matchedSlots[idx] then
+					tinsert(remainingTargets, idx)
+				end
+			end
+
+			for i = 1, #remainingIdx do
+				matchedItems[remainingIdx[i]] = remainingTargets[i]
+			end
+
+			local temp = {}
+			for srcIdx, destIdx in pairs(matchedItems) do
+				temp[destIdx] = items[srcIdx]
+			end
+
+			for _, idx in ipairs(indices) do
+				order[idx] = temp[idx]
+			end
+		end
+	end
 end
 
 


### PR DESCRIPTION
This PR introduces optimizations to the client-side sorting algorithm (sorting.lua) to reduce the total number of moves/swaps required to sort bags, which is particularly beneficial in lag-sensitive environments like the Guild Bank:

Identical Item Matching (OptimizeOrder): Identical items (same itemID and stackCount) are matched to target slots so that any item already sitting in a valid target slot remains in-place. This minimizes cycles and prevents redundant swaps.
Skip Redundant Swaps: Moves are skipped if the target slot already contains an identical item.
Throttled Moves for Server-Bound Containers: To prevent server-side transaction drops/failures in the Guild Bank and Void Storage (which strictly rate-limit operations), the algorithm now returns early after initiating a move on these specific containers (detected via self.target.id == 'guild' or 'vault'). This limits them to 1 move per tick (50ms), while allowing character bags and the normal bank to continue sorting instantly in a single tick as before.