### PR TITLE
Fix reverse sorting space indexing bug

### DIFF
--- a/core/api/sorting.lua
+++ b/core/api/sorting.lua
@@ -114,19 +114,22 @@ function Sort:GetSpaces()
 					item = {}
 				end
 
-				tinsert(spaces, {index = #spaces, bag = bag, slot = slot, family = family, item = item})
+				tinsert(spaces, {bag = bag, slot = slot, family = family, item = item})
 				item.space = spaces[#spaces]
 			end
 		end
 	end
 
 	if self.target.profile.reverseSort then
-		local n, k = #spaces
+		local n = #spaces
 		for i = 1, math.floor(n / 2) do
-			k = n - i + 1
+			local k = n - i + 1
 			spaces[i], spaces[k] = spaces[k], spaces[i]
-			spaces[i].index, spaces[k].index = i, k
 		end
+	end
+
+	for i = 1, #spaces do
+		spaces[i].index = i
 	end
 
 	return spaces


### PR DESCRIPTION
Fixes an issue where sorts are unstable for bags with odd numbers of slots (due to locking, etc).

Fixes Jaliborc/Bagnon@2192 (https://github.com/Jaliborc/Bagnon/issues/2192)