### PR TITLE
Consistently return Addon.None for empty slots in Vault and Guild Bank

### DIFF
--- a/frames/guild/guild.lua
+++ b/frames/guild/guild.lua
@@ -73,7 +73,7 @@ function Guild:GetItemInfo(bag, slot)
 		_, _, item.quality = GetItemInfo(link) 
 		return item
 	end
-	return {}
+	return Addon.None
 end
 
 function Guild:IsCached()

--- a/frames/vault/vault.lua
+++ b/frames/vault/vault.lua
@@ -114,11 +114,13 @@ function Vault:GetItemInfo(bag, slot)
 
 		if item.itemID then
 			_, item.hyperlink = GetItemInfo(item.itemID) 
+			return item
 		end
-		return item
+		return Addon.None
 	elseif bag == 1 then
 		return self:Super(Vault):GetItemInfo(bag, slot)
 	end
+	return Addon.None
 end
 
 function Vault:GetBagInfo(bag)


### PR DESCRIPTION
This PR ensures consistent return types for empty slots in the Vault and Guild Bank frames, which could in rare cases cause a null reference or extra GC overhead.

Fixes Jaliborc/Bagnon#2194