### PR TITLE
guard against unresolved item hyperlink in Pawn upgrade check

### DIFF
--- a/core/classes/item.lua
+++ b/core/classes/item.lua
@@ -285,7 +285,10 @@ function Item:GetQuestInfo()
 end
 
 function Item:IsUpgrade()
-	return (self.hasItem or false) and C.AddOns.IsAddOnLoaded('Pawn') and PawnShouldItemLinkHaveUpgradeArrow(self.info.hyperlink)
+	if self.hasItem and C.AddOns.IsAddOnLoaded('Pawn') then
+		return self.info and self.info.hyperlink and PawnShouldItemLinkHaveUpgradeArrow(self.info.hyperlink)
+	end
+	return false
 end
 
 function Item:GetInventorySlot()


### PR DESCRIPTION
Guards against calling PawnShouldItemLinkHaveUpgradeArrow with a nil hyperlink when item information has not finished caching during bank updates. Returns nil when the hyperlink is missing so UpdateUpgradeIcon can schedule its 0.5s delay retry.

Fixes Jaliborc/Bagnon#2189