### PR TITLE
Fix right-click item usage blocking in Retail

### DIFF
--- a/frames/inventory/item.lua
+++ b/frames/inventory/item.lua
@@ -40,7 +40,7 @@ end
 
 if C.Bank.AreAnyBankTypesViewable then
 	function Item:PreClick(button)
-		if C.Bank.AreAnyBankTypesViewable() and self.hasItem then
+		if Addon.Events.AtBank and self.hasItem then
 			if button == 'RightButton' and Addon.Frames:IsEnabled('bank') then
 				local bankType = Addon_GetBankType()
 				bankType = IsShiftKeyDown() and (2 - bankType) or bankType


### PR DESCRIPTION
In Retail WoW (11.0+), `C_Bank.AreAnyBankTypesViewable()` evaluates to true globally across the game world. In commit 263bfaefda854be3f43564a388eb8f31bda88572 (September 2025), `Item:PreClick` was updated to check `C.Bank.AreAnyBankTypesViewable()` instead of `Addon.Events.AtBank`.

Because of this, `Item:PreClick` intercepted every right-click in the open world, invoking `C.Container.UseContainerItem` with bank transfer parameters and blocking/tainting the usage of consumables, blueprints, glyphs, and other items outside of a bank.

This change restores the `Addon.Events.AtBank` guard so `UseContainerItem` is only executed while actively interacting with a bank NPC.

Fixes Jaliborc/Bagnon#2188