### PR TITLE
Fix currency caching for quality 0 currencies

### DIFF
--- a/core/features/caching.lua
+++ b/core/features/caching.lua
@@ -82,7 +82,7 @@ function Cacher:OnLoad()
 
 	for id = 1, 5000 do
 		local data = C.CurrencyInfo.GetCurrencyInfo(id)
-		if data and data.quantity > 0 and data.quality > 0 and not C.CurrencyInfo.IsAccountWideCurrency(id) then
+		if data and data.quantity > 0 and not C.CurrencyInfo.IsAccountWideCurrency(id) then
 			self.player.currency[id] = data.quantity
 		end
 	end


### PR DESCRIPTION
- Remove `data.quality > 0` condition from `Cacher:OnLoad()` currency scan.
- In 11.0+, Warband transferable currencies (such as Voidlight Marl or Polished Pet Charms) have an item quality value of 0 (Poor/Default quality).
- Previously, `data.quality > 0` caused the login scan to skip caching any currency with quality 0, leaving alt currency counts stale in SavedVariables even after logging into those characters.

Fixes Jaliborc/Bagnon#2169